### PR TITLE
Make grider jQuery 1.7 compatible

### DIFF
--- a/grider.js
+++ b/grider.js
@@ -41,7 +41,7 @@
   * @attr summary: Defines the type of calculation it will be done on the column,
   * operations that can be done are "sum", "avg", "max", "min" and "count"
   *
-  * @attr formula: Calculates the formula with the columns you defined, right now it does simple calculations, 
+  * @attr formula: Calculates the formula with the columns you defined, right now it does simple calculations,
   * the formula is evaluated eval(formula), to calculate
   *
   * Configurations for the config variable
@@ -101,7 +101,7 @@
                     });
                 }
             }
- 
+
             var l = $(table).find("tr:not(.noedit):first td").length;
             for(var i = 0; i < l; i++) {
                 setColumn(t.rows[0].cells[i], i);
@@ -144,7 +144,7 @@
                 $(table).find('tr:not(.noedit)').each(function(index,elem){
                     $(elem).append(config['delRowText']);
                 });
-                $(table).find('a.delete').live("click", function(){
+                $(document).on("click", $(table).find('a.delete'), function() {
                     delRow(this);
                     return true;
                 });
@@ -161,7 +161,7 @@
          * Allows to add a new row, the new row is added at the endof the editable rows
          */
         function addRowWithTab() {
-            $(table).find("tr:not(.noedit):last a.delete").live("keydown",function(e) {
+            $(document).on("keydown", $(table).find("tr:not(.noedit):last a.delete"), function(e) {
                 if(e.keyCode == 9) {
                     addRow();
                 }


### PR DESCRIPTION
As of jQuery 1.7, the .live() method is deprecated. I replace that with the .on() method.
